### PR TITLE
Implement `rename` config section

### DIFF
--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -53,9 +53,17 @@ type PuppetContentTemplateInfo struct {
 // PuppetContentTemplate houses the actual information about each template
 type PuppetContentTemplate struct {
 	install.ConfigParams `mapstructure:",squash"`
-	Type                 string `mapstructure:"type"`
-	Display              string `mapstructure:"display"`
-	URL                  string `mapstructure:"url"`
+	Type                 string        `mapstructure:"type"`
+	Display              string        `mapstructure:"display"`
+	URL                  string        `mapstructure:"url"`
+	Rename               []RenameEntry `mapstructure:"rename"`
+}
+
+// RenameEntry maps a source file path in the content directory to a target
+// output path using template expressions.
+type RenameEntry struct {
+	Source string `mapstructure:"source"`
+	Target string `mapstructure:"target"`
 }
 
 // PuppetContentTemplateFileInfo represents the resolved target path information
@@ -282,13 +290,26 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 	)
 
 	var templateFiles []PuppetContentTemplateFileInfo
-	err := p.AFS.Walk(contentDir, func(path string, info os.FileInfo, err error) error {
+	config := p.processConfiguration(info)
+	err := p.AFS.Walk(contentDir, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
 		log.Trace().Msgf("Processing: %s", path)
+
 		targetFile := replacer.Replace(path)
+		relPath, relErr := filepath.Rel(contentDir, path)
+		if relErr == nil {
+			if entry, isPrefix := findRename(relPath, tmpl.Template.Rename); entry != nil {
+				rendered := p.renderTarget(entry.Target, config)
+				if isPrefix {
+					targetFile = filepath.Join(info.TargetOutputDir, strings.Replace(relPath, entry.Source, rendered, 1))
+				} else {
+					targetFile = filepath.Join(info.TargetOutputDir, rendered)
+				}
+			}
+		}
 		log.Debug().Msgf("Resolved '%s' to '%s'", path, targetFile)
 
 		dir, file := filepath.Split(targetFile)
@@ -297,7 +318,7 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 			TargetFilePath: targetFile,
 			TargetDir:      dir,
 			TargetFile:     file,
-			IsDirectory:    info.IsDir(),
+			IsDirectory:    fi.IsDir(),
 		}
 		log.Trace().Msgf("Processed: %+v", i)
 
@@ -317,7 +338,7 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 				deployed = append(deployed, templateFile.TargetFilePath)
 			}
 		} else {
-			err := p.createTemplateFile(info, templateFile)
+			err := p.createTemplateFile(templateFile, config)
 			if err != nil {
 				log.Error().Msgf("%s", err)
 				continue
@@ -341,9 +362,8 @@ func (p *Pct) createTemplateDirectory(targetDir string) error {
 	return nil
 }
 
-func (p *Pct) createTemplateFile(info DeployInfo, templateFile PuppetContentTemplateFileInfo) error {
+func (p *Pct) createTemplateFile(templateFile PuppetContentTemplateFileInfo, config map[string]interface{}) error {
 	log.Trace().Msgf("Creating: '%s'", templateFile.TargetFilePath)
-	config := p.processConfiguration(info)
 
 	text, err := p.renderFile(templateFile.TemplatePath, config)
 	if err != nil {
@@ -542,6 +562,42 @@ func (p *Pct) process(t *template.Template, vars interface{}) string {
 		return ""
 	}
 	return tmplBytes.String()
+}
+
+func (p *Pct) renderTarget(targetTmpl string, vars map[string]interface{}) string {
+	tmpl := template.New("target").Funcs(template.FuncMap{
+		"toClassName": utils.ToClassName,
+		"ns2path":     utils.Ns2Path,
+	})
+	tmpl, err := tmpl.Parse(targetTmpl)
+	if err != nil {
+		log.Error().Msgf("Error parsing target template: %v", err)
+		return targetTmpl
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, vars)
+	if err != nil {
+		log.Error().Msgf("Error executing target template: %v", err)
+		return targetTmpl
+	}
+	return buf.String()
+}
+
+func findRename(relPath string, entries []RenameEntry) (entry *RenameEntry, isPrefix bool) {
+	for _, e := range entries {
+		if e.Source == relPath {
+			return &e, false
+		}
+	}
+	var best *RenameEntry
+	bestLen := 0
+	for _, e := range entries {
+		if strings.HasPrefix(relPath, e.Source+string(filepath.Separator)) && len(e.Source) > bestLen {
+			best = &e
+			bestLen = len(e.Source)
+		}
+	}
+	return best, best != nil
 }
 
 func (p *Pct) FilterFiles(ss []PuppetContentTemplate, test func(PuppetContentTemplate) bool) (ret []PuppetContentTemplate) {

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -288,11 +288,6 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 	log.Debug().Msgf("Target Name: %s", info.TargetName)
 	log.Debug().Msgf("Target Output: %s", info.TargetOutputDir)
 
-	replacer := strings.NewReplacer(
-		contentDir, info.TargetOutputDir,
-		".tmpl", "",
-	)
-
 	var templateFiles []PuppetContentTemplateFileInfo
 	config := p.processConfiguration(info)
 	err := p.AFS.Walk(contentDir, func(path string, fi os.FileInfo, err error) error {
@@ -302,8 +297,8 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 
 		log.Trace().Msgf("Processing: %s", path)
 
-		targetFile := replacer.Replace(path)
 		relPath, relErr := filepath.Rel(contentDir, path)
+		targetFile := filepath.Join(info.TargetOutputDir, relPath)
 		if relErr == nil {
 			if entry, isPrefix := findRename(relPath, tmpl.Template.Rename); entry != nil {
 				rendered := p.renderTarget(entry.Target, config)

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -29,8 +29,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"gopkg.in/yaml.v2"
 )
 
@@ -516,9 +514,7 @@ func (p *Pct) renderFile(fileName string, vars interface{}) (string, error) {
 		New(filepath.Base(fileName)).
 		Funcs(
 			template.FuncMap{
-				"toClassName": func(itemName string) string {
-					return cases.Title(language.Und).String(itemName)
-				},
+				"toClassName": utils.ToClassName,
 			},
 		)
 	// This is not ideal, but this function needs to be toggled

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -44,6 +44,11 @@ const (
 	TemplateTypeProject = "project"
 )
 
+var tmplFuncs = template.FuncMap{
+	"toClassName": utils.ToClassName,
+	"ns2path":     utils.Ns2Path,
+}
+
 // PuppetContentTemplateInfo is the housing struct for marshaling YAML data
 type PuppetContentTemplateInfo struct {
 	Template PuppetContentTemplate `mapstructure:"template"`
@@ -532,11 +537,7 @@ func (p *Pct) readTemplateConfig(configFile string) PuppetContentTemplateInfo {
 func (p *Pct) renderFile(fileName string, vars interface{}) (string, error) {
 	renderedTmpl := template.
 		New(filepath.Base(fileName)).
-		Funcs(
-			template.FuncMap{
-				"toClassName": utils.ToClassName,
-			},
-		)
+		Funcs(tmplFuncs)
 	// This is not ideal, but this function needs to be toggled
 	// if we are running with aferos in memory file system
 	// if the file doesnt exist on the os then check if its part of afero
@@ -565,10 +566,7 @@ func (p *Pct) process(t *template.Template, vars interface{}) string {
 }
 
 func (p *Pct) renderTarget(targetTmpl string, vars map[string]interface{}) string {
-	tmpl := template.New("target").Funcs(template.FuncMap{
-		"toClassName": utils.ToClassName,
-		"ns2path":     utils.Ns2Path,
-	})
+	tmpl := template.New("target").Funcs(tmplFuncs)
 	tmpl, err := tmpl.Parse(targetTmpl)
 	if err != nil {
 		log.Error().Msgf("Error parsing target template: %v", err)

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -290,7 +290,6 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 
 	replacer := strings.NewReplacer(
 		contentDir, info.TargetOutputDir,
-		"{{pct_name}}", info.TargetName,
 		".tmpl", "",
 	)
 

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -298,6 +298,9 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 		log.Trace().Msgf("Processing: %s", path)
 
 		relPath, relErr := filepath.Rel(contentDir, path)
+		if relErr == nil {
+			relPath = filepath.ToSlash(relPath)
+		}
 		targetFile := filepath.Join(info.TargetOutputDir, relPath)
 		if relErr == nil {
 			if entry, isPrefix := findRename(relPath, tmpl.Template.Rename); entry != nil {
@@ -576,6 +579,7 @@ func (p *Pct) renderTarget(targetTmpl string, vars map[string]interface{}) strin
 }
 
 func findRename(relPath string, entries []RenameEntry) (entry *RenameEntry, isPrefix bool) {
+	relPath = filepath.ToSlash(relPath)
 	for _, e := range entries {
 		if e.Source == relPath {
 			return &e, false
@@ -584,7 +588,7 @@ func findRename(relPath string, entries []RenameEntry) (entry *RenameEntry, isPr
 	var best *RenameEntry
 	bestLen := 0
 	for _, e := range entries {
-		if strings.HasPrefix(relPath, e.Source+string(filepath.Separator)) && len(e.Source) > bestLen {
+		if strings.HasPrefix(relPath, e.Source+"/") && len(e.Source) > bestLen {
 			best = &e
 			bestLen = len(e.Source)
 		}

--- a/internal/pkg/pct/pct_test.go
+++ b/internal/pkg/pct/pct_test.go
@@ -188,6 +188,139 @@ Summary: {{.example_replace.summary}}`,
 			},
 		},
 		{
+			name: "deploy with rename entry",
+			args: args{
+				info: pct.DeployInfo{
+					SelectedTemplate: "rename-test",
+					TemplateDirPath:  "templates/author/id/0.1.0",
+					TargetOutputDir:  filepath.Join(tmp, "out"),
+					TargetName:       "my_module",
+					PdkInfo: pct.PDKInfo{
+						Version:   "0.1.0",
+						Commit:    "abc12345",
+						BuildDate: "2021/06/27",
+					},
+				},
+				templateConfig: `---
+template:
+  id: rename-test
+  type: item
+  rename:
+    - source: "class.pp"
+      target: "manifests/{{.pct_name}}.pp"
+`,
+				templateContent: map[string]string{
+					"class.pp": "class {{.pct_name}} { }",
+				},
+			},
+			want: []string{
+				filepath.Join(tmp, "out"),
+				filepath.Join(tmp, "out", "manifests", "my_module.pp"),
+			},
+		},
+		{
+			name: "deploy with rename ns2path filter",
+			args: args{
+				info: pct.DeployInfo{
+					SelectedTemplate: "ns2path-test",
+					TemplateDirPath:  "templates/author/id/0.1.0",
+					TargetOutputDir:  filepath.Join(tmp, "out"),
+					TargetName:       "profile::base",
+					PdkInfo: pct.PDKInfo{
+						Version:   "0.1.0",
+						Commit:    "abc12345",
+						BuildDate: "2021/06/27",
+					},
+				},
+				templateConfig: `---
+template:
+  id: ns2path-test
+  type: item
+  rename:
+    - source: "class.pp"
+      target: "manifests/{{.pct_name | ns2path}}.pp"
+`,
+				templateContent: map[string]string{
+					"class.pp": "class {{.pct_name}} { }",
+				},
+			},
+			want: []string{
+				filepath.Join(tmp, "out"),
+				filepath.Join(tmp, "out", "manifests", "profile", "base.pp"),
+			},
+		},
+		{
+			name: "deploy with prefix match explicit override and untemplated files",
+			args: args{
+				info: pct.DeployInfo{
+					SelectedTemplate: "prefix-override-test",
+					TemplateDirPath:  "templates/author/id/0.1.0",
+					TargetOutputDir:  filepath.Join(tmp, "out"),
+					TargetName:       "my_provider",
+					PdkInfo: pct.PDKInfo{
+						Version:   "0.1.0",
+						Commit:    "abc12345",
+						BuildDate: "2021/06/27",
+					},
+				},
+				templateConfig: `---
+template:
+  id: prefix-override-test
+  type: item
+  rename:
+    - source: "provider_dir"
+      target: "lib/puppet/provider/{{.pct_name}}"
+    - source: "provider_dir/provider_spec.rb"
+      target: "lib/puppet/provider/{{.pct_name}}/{{.pct_name}}_spec.rb"
+`,
+				templateContent: map[string]string{
+					"provider_dir/provider.rb":      "code",
+					"provider_dir/provider_spec.rb": "spec",
+					"provider_dir/subdir/helper.rb": "helper",
+				},
+			},
+			want: []string{
+				filepath.Join(tmp, "out"),
+				filepath.Join(tmp, "out", "lib", "puppet", "provider", "my_provider"),
+				filepath.Join(tmp, "out", "lib", "puppet", "provider", "my_provider", "provider.rb"),
+				filepath.Join(tmp, "out", "lib", "puppet", "provider", "my_provider", "my_provider_spec.rb"),
+				filepath.Join(tmp, "out", "lib", "puppet", "provider", "my_provider", "subdir"),
+				filepath.Join(tmp, "out", "lib", "puppet", "provider", "my_provider", "subdir", "helper.rb"),
+			},
+		},
+		{
+			name: "deploy with rename directory entry",
+			args: args{
+				info: pct.DeployInfo{
+					SelectedTemplate: "dir-rename-test",
+					TemplateDirPath:  "templates/author/id/0.1.0",
+					TargetOutputDir:  filepath.Join(tmp, "out"),
+					TargetName:       "my_provider",
+					PdkInfo: pct.PDKInfo{
+						Version:   "0.1.0",
+						Commit:    "abc12345",
+						BuildDate: "2021/06/27",
+					},
+				},
+				templateConfig: `---
+template:
+  id: dir-rename-test
+  type: item
+  rename:
+    - source: "provider_dir"
+      target: "lib/puppet/provider/{{.pct_name}}"
+`,
+				templateContent: map[string]string{
+					"provider_dir/provider.rb": "require 'puppet'",
+				},
+			},
+			want: []string{
+				filepath.Join(tmp, "out"),
+				filepath.Join(tmp, "out", "lib", "puppet", "provider", "my_provider"),
+				filepath.Join(tmp, "out", "lib", "puppet", "provider", "my_provider", "provider.rb"),
+			},
+		},
+		{
 			name: "deploy a item without an outputDir",
 			args: args{
 				info: pct.DeployInfo{

--- a/internal/pkg/pct/pct_test.go
+++ b/internal/pkg/pct/pct_test.go
@@ -146,7 +146,7 @@ template:
 
 `,
 				templateContent: map[string]string{
-					"replace.txt.tmpl": `This is example text
+					"replace.txt": `This is example text
 
 Summary: {{.example_replace.summary}}`,
 				},
@@ -177,7 +177,7 @@ template:
 
 `,
 				templateContent: map[string]string{
-					"replace.txt.tmpl": `This is example text
+					"replace.txt": `This is example text
 
 Summary: {{.example_replace.summary}}`,
 				},
@@ -341,7 +341,7 @@ template:
 
 `,
 				templateContent: map[string]string{
-					"replace.txt.tmpl": `This is example text
+					"replace.txt": `This is example text
 
 Summary: {{.example_replace.summary}}`,
 				},

--- a/internal/pkg/pct/pct_test.go
+++ b/internal/pkg/pct/pct_test.go
@@ -146,14 +146,14 @@ template:
 
 `,
 				templateContent: map[string]string{
-					"{{pct_name}}.txt.tmpl": `This is example text
+					"replace.txt.tmpl": `This is example text
 
 Summary: {{.example_replace.summary}}`,
 				},
 			},
 			want: []string{
 				filepath.Join(tmp, "thing"),
-				filepath.Join(tmp, "thing", "woo.txt"),
+				filepath.Join(tmp, "thing", "replace.txt"),
 			},
 		},
 		{
@@ -177,14 +177,14 @@ template:
 
 `,
 				templateContent: map[string]string{
-					"{{pct_name}}.txt.tmpl": `This is example text
+					"replace.txt.tmpl": `This is example text
 
 Summary: {{.example_replace.summary}}`,
 				},
 			},
 			want: []string{
 				tmp,
-				filepath.Join(tmp, filepath.Base(tmp)+".txt"),
+				filepath.Join(tmp, "replace.txt"),
 			},
 		},
 		{
@@ -341,14 +341,14 @@ template:
 
 `,
 				templateContent: map[string]string{
-					"{{pct_name}}.txt.tmpl": `This is example text
+					"replace.txt.tmpl": `This is example text
 
 Summary: {{.example_replace.summary}}`,
 				},
 			},
 			want: []string{
 				tmp,
-				filepath.Join(tmp, "wibble.txt"),
+				filepath.Join(tmp, "replace.txt"),
 			},
 		},
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/rs/zerolog/log"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // contains checks if a string is present in a slice
@@ -60,4 +62,10 @@ func GetDefaultTemplatePath() (string, error) {
 	defaultTemplatePath := filepath.Join(filepath.Dir(execDir), "templates")
 	log.Trace().Msgf("Default template path: %v", defaultTemplatePath)
 	return defaultTemplatePath, nil
+}
+
+// ToClassName capitalises the first letter of a name.
+// "my_class" -> "My_class"
+func ToClassName(s string) string {
+	return cases.Title(language.Und).String(s)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"golang.org/x/text/cases"
@@ -68,4 +69,10 @@ func GetDefaultTemplatePath() (string, error) {
 // "my_class" -> "My_class"
 func ToClassName(s string) string {
 	return cases.Title(language.Und).String(s)
+}
+
+// Ns2Path converts a Puppet namespace separator to a file path separator.
+// "profile::base" -> "profile/base"
+func Ns2Path(s string) string {
+	return strings.ReplaceAll(s, "::", "/")
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -25,6 +25,26 @@ func TestToClassName(t *testing.T) {
 	}
 }
 
+func TestNs2Path(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"double colon", "profile::base", "profile/base"},
+		{"triple nested", "a::b::c", "a/b/c"},
+		{"no namespace", "foo", "foo"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Ns2Path(tt.arg); got != tt.want {
+				t.Errorf("Ns2Path() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestContains(t *testing.T) {
 	type args struct {
 		s   []string

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestToClassName(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"snake_case", "my_class", "My_class"},
+		{"single word", "foo", "Foo"},
+		{"empty string", "", ""},
+		{"multiple underscores", "a_b_c", "A_b_c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToClassName(tt.arg); got != tt.want {
+				t.Errorf("ToClassName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestContains(t *testing.T) {
 	type args struct {
 		s   []string


### PR DESCRIPTION
The `rename` config section allows to template file names. Previously, `{{pct_name}}` was just a string replacement. Now any templating engine functions are allowed.