### PR TITLE
feat: add Engine interface for content and filenames

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,3 +78,4 @@ formatters:
 
 issues:
   max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -48,7 +48,7 @@ func (ic *InstallCommand) executeInstall(cmd *cobra.Command, args []string) erro
 	var err error = nil
 	if ic.GitUri != "" { // For cloning a template
 		// Create temp folder
-		tempDir, dirErr := ic.AFS.TempDir("", "")
+		tempDir, dirErr := ic.AFS.TempDir(ic.InstallPath, ".pct")
 		defer func() {
 			dirErr := ic.AFS.Remove(tempDir)
 			if dirErr != nil {

--- a/cmd/new/new.go
+++ b/cmd/new/new.go
@@ -124,7 +124,8 @@ func flagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]str
 
 func completeName(match string) []string {
 	var names []string
-	for _, tmpl := range cachedTemplates {
+	for i := range cachedTemplates {
+		tmpl := &cachedTemplates[i]
 		namespacedTemplate := fmt.Sprintf("%s/%s", tmpl.Author, tmpl.Id)
 		if strings.HasPrefix(namespacedTemplate, match) {
 			m := namespacedTemplate + "\t" + tmpl.Display

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -129,8 +129,6 @@ func (p *Pct) GetInfo(templateDirPath string) (PuppetContentTemplateInfo, error)
 // debug log events
 func (p *Pct) List(templatePath string, templateName string) []PuppetContentTemplate {
 	log.Debug().Msgf("Searching %+v for templates", templatePath)
-	// Triple glob to match author/id/version/TemplateConfigFileName
-	// TODO: Make this backward compatible
 	matches, _ := p.IOFS.Glob(templatePath + "/**/**/**/" + TemplateConfigFileName)
 
 	var tmpls []PuppetContentTemplate
@@ -142,17 +140,6 @@ func (p *Pct) List(templatePath string, templateName string) []PuppetContentTemp
 			tmpls = append(tmpls, i)
 		}
 	}
-	// Temporary workaround to find old layout templates
-	oldMatches, _ := p.IOFS.Glob(templatePath + "/**/" + TemplateConfigFileName)
-	for _, file := range oldMatches {
-		log.Debug().Msgf("Found: %+v", file)
-		i := p.readTemplateConfig(file).Template
-		// Do not write id-less configs (ie, invalid, could not parse) to the return
-		if i.Id != "" {
-			tmpls = append(tmpls, i)
-		}
-	}
-
 	if templateName != "" {
 		log.Debug().Msgf("Filtering for: %s", templateName)
 		tmpls = p.FilterFiles(tmpls, func(f PuppetContentTemplate) bool { return f.Id == templateName })

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -10,17 +10,16 @@ Puppet Class or a set of CI files to add to a Puppet Module.
 package pct
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
 	"sort"
 	"strings"
-	"text/template"
 
 	"github.com/hashicorp/go-version"
 	"github.com/jay7x/pct/pkg/install"
+	"github.com/jay7x/pct/pkg/template"
 	"github.com/jay7x/pct/pkg/utils"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/olekukonko/tablewriter"
@@ -44,11 +43,6 @@ const (
 	TemplateTypeProject = "project"
 )
 
-var tmplFuncs = template.FuncMap{
-	"toClassName": utils.ToClassName,
-	"ns2path":     utils.Ns2Path,
-}
-
 // PuppetContentTemplateInfo is the housing struct for marshaling YAML data
 type PuppetContentTemplateInfo struct {
 	Template PuppetContentTemplate `mapstructure:"template"`
@@ -61,6 +55,7 @@ type PuppetContentTemplate struct {
 	Type                 string        `mapstructure:"type"`
 	Display              string        `mapstructure:"display"`
 	URL                  string        `mapstructure:"url"`
+	Engine               string        `mapstructure:"engine"`
 	Rename               []RenameEntry `mapstructure:"rename"`
 }
 
@@ -291,6 +286,12 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 
 	var templateFiles []PuppetContentTemplateFileInfo
 	config := p.processConfiguration(info)
+
+	engineName := tmpl.Template.Engine
+	if engineName == "" {
+		engineName = template.DefaultEngineName
+	}
+
 	err := p.AFS.Walk(contentDir, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -305,7 +306,7 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 		targetFile := filepath.Join(info.TargetOutputDir, relPath)
 		if relErr == nil {
 			if entry, isPrefix := findRename(relPath, tmpl.Template.Rename); entry != nil {
-				rendered := p.renderTarget(entry.Target, config)
+				rendered := p.renderTarget(entry.Target, config, engineName)
 				if isPrefix {
 					targetFile = filepath.Join(info.TargetOutputDir, strings.Replace(relPath, entry.Source, rendered, 1))
 				} else {
@@ -341,7 +342,7 @@ func (p *Pct) Deploy(info DeployInfo) []string {
 				deployed = append(deployed, templateFile.TargetFilePath)
 			}
 		} else {
-			err := p.createTemplateFile(templateFile, config)
+			err := p.createTemplateFile(templateFile, config, engineName)
 			if err != nil {
 				log.Error().Msgf("%s", err)
 				continue
@@ -365,10 +366,10 @@ func (p *Pct) createTemplateDirectory(targetDir string) error {
 	return nil
 }
 
-func (p *Pct) createTemplateFile(templateFile PuppetContentTemplateFileInfo, config map[string]interface{}) error {
+func (p *Pct) createTemplateFile(templateFile PuppetContentTemplateFileInfo, config map[string]interface{}, engineName string) error {
 	log.Trace().Msgf("Creating: '%s'", templateFile.TargetFilePath)
 
-	text, err := p.renderFile(templateFile.TemplatePath, config)
+	text, err := p.renderFile(templateFile.TemplatePath, config, engineName)
 	if err != nil {
 		return fmt.Errorf("Failed to create %s", templateFile.TargetFilePath)
 	}
@@ -532,51 +533,36 @@ func (p *Pct) readTemplateConfig(configFile string) PuppetContentTemplateInfo {
 	return config
 }
 
-func (p *Pct) renderFile(fileName string, vars interface{}) (string, error) {
-	renderedTmpl := template.
-		New(filepath.Base(fileName)).
-		Funcs(tmplFuncs)
-	// This is not ideal, but this function needs to be toggled
-	// if we are running with aferos in memory file system
-	// if the file doesnt exist on the os then check if its part of afero
-	tmpl, err := renderedTmpl.ParseFiles(fileName)
-	if os.IsNotExist(err) {
-		tmpl, err = renderedTmpl.ParseFS(p.IOFS, fileName)
-
-		if err != nil {
-			log.Error().Msgf("Error parsing config: %v", err)
-			return "", err
-		}
+func (p *Pct) renderFile(fileName string, vars map[string]interface{}, engineName string) (string, error) {
+	if engineName == "" {
+		engineName = template.DefaultEngineName
 	}
-
-	return p.process(tmpl, vars), nil
+	eng, ok := template.Get(engineName)
+	if !ok {
+		return "", fmt.Errorf("unknown template engine: %s", engineName)
+	}
+	content, err := p.AFS.ReadFile(fileName)
+	if err != nil {
+		return "", fmt.Errorf("Failed to read %s: %w", fileName, err)
+	}
+	return eng.Render(string(content), vars)
 }
 
-func (p *Pct) process(t *template.Template, vars interface{}) string {
-	var tmplBytes bytes.Buffer
-
-	err := t.Execute(&tmplBytes, vars)
-	if err != nil {
-		log.Error().Msgf("Error parsing config: %v", err)
-		return ""
+func (p *Pct) renderTarget(targetTmpl string, vars map[string]interface{}, engineName string) string {
+	if engineName == "" {
+		engineName = template.DefaultEngineName
 	}
-	return tmplBytes.String()
-}
-
-func (p *Pct) renderTarget(targetTmpl string, vars map[string]interface{}) string {
-	tmpl := template.New("target").Funcs(tmplFuncs)
-	tmpl, err := tmpl.Parse(targetTmpl)
-	if err != nil {
-		log.Error().Msgf("Error parsing target template: %v", err)
+	eng, ok := template.Get(engineName)
+	if !ok {
+		log.Error().Msgf("unknown template engine: %s", engineName)
 		return targetTmpl
 	}
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, vars)
+	out, err := eng.Render(targetTmpl, vars)
 	if err != nil {
 		log.Error().Msgf("Error executing target template: %v", err)
 		return targetTmpl
 	}
-	return buf.String()
+	return out
 }
 
 func findRename(relPath string, entries []RenameEntry) (entry *RenameEntry, isPrefix bool) {

--- a/internal/pkg/pct/pct.go
+++ b/internal/pkg/pct/pct.go
@@ -195,7 +195,8 @@ func (*Pct) FormatTemplates(tmpls []PuppetContentTemplate, jsonOutput string) (s
 				})),
 			)
 			table.Header([]string{"DisplayName", "Author", "Name", "Type"})
-			for _, v := range tmpls {
+			for i := range tmpls {
+				v := &tmpls[i]
 				_ = table.Append([]string{v.Display, v.Author, v.Id, v.Type})
 			}
 			_ = table.Render()
@@ -597,18 +598,18 @@ func findRename(relPath string, entries []RenameEntry) (entry *RenameEntry, isPr
 }
 
 func (p *Pct) FilterFiles(ss []PuppetContentTemplate, test func(PuppetContentTemplate) bool) (ret []PuppetContentTemplate) {
-	for _, s := range ss {
-		if test(s) {
-			ret = append(ret, s)
+	for i := range ss {
+		if test(ss[i]) {
+			ret = append(ret, ss[i])
 		}
 	}
 	return
 }
 
 func (p *Pct) filterNewestVersions(tt []PuppetContentTemplate) (ret []PuppetContentTemplate) {
-	for _, t := range tt {
-		id := t.Id
-		author := t.Author
+	for i := range tt {
+		id := tt[i].Id
+		author := tt[i].Author
 		// Look for templates with the same author and id
 		templates := p.FilterFiles(tt, func(f PuppetContentTemplate) bool { return f.Id == id && f.Author == author })
 		if len(templates) > 1 {
@@ -617,8 +618,8 @@ func (p *Pct) filterNewestVersions(tt []PuppetContentTemplate) (ret []PuppetCont
 			if len(p.FilterFiles(ret, func(f PuppetContentTemplate) bool { return f.Id == id && f.Author == author })) == 0 {
 				// turn the version strings into version objects for sorting and comparison
 				versionsRaw := []string{}
-				for _, t := range templates {
-					versionsRaw = append(versionsRaw, t.Version)
+				for j := range templates {
+					versionsRaw = append(versionsRaw, templates[j].Version)
 				}
 				versions := make([]*version.Version, len(versionsRaw))
 				for i, raw := range versionsRaw {
@@ -636,7 +637,7 @@ func (p *Pct) filterNewestVersions(tt []PuppetContentTemplate) (ret []PuppetCont
 			}
 		} else {
 			// If the author/id template only has 1 entry, it's already the latest version
-			ret = append(ret, t)
+			ret = append(ret, tt[i])
 		}
 	}
 

--- a/internal/pkg/pct_config_processor/pct_config_processor.go
+++ b/internal/pkg/pct_config_processor/pct_config_processor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jay7x/pct/internal/pkg/pct"
 	"github.com/jay7x/pct/pkg/config_processor"
@@ -47,8 +48,14 @@ func (p *PctConfigProcessor) CheckConfig(configFile string) error {
 	if info.Template.Id == "" {
 		msg += "  * id\n"
 	}
+	if strings.HasPrefix(info.Template.Id, ".") {
+		msg += "  * id must not start with '.'\n"
+	}
 	if info.Template.Author == "" {
 		msg += "  * author\n"
+	}
+	if strings.HasPrefix(info.Template.Author, ".") {
+		msg += "  * author must not start with '.'\n"
 	}
 	if info.Template.Version == "" {
 		msg += "  * version\n"

--- a/internal/pkg/pct_config_processor/pct_config_processor_test.go
+++ b/internal/pkg/pct_config_processor/pct_config_processor_test.go
@@ -110,6 +110,45 @@ foo: bar
 `,
 			errorMsg: `The following attributes are missing in .+:\s+\* id\s+\* author\s+\* version`,
 		},
+		{
+			name:           "When config author starts with '.'",
+			mockConfigFile: true,
+			configFilePath: "my/dotfile/author/pct-config.yml",
+
+			configFileYaml: `---
+template:
+  id: test-template
+  author: .hidden
+  version: 0.1.0
+`,
+			errorMsg: `The following attributes are missing in .+:\s+\* author must not start with '\.'`,
+		},
+		{
+			name:           "When config id starts with '.'",
+			mockConfigFile: true,
+			configFilePath: "my/dotfile/id/pct-config.yml",
+
+			configFileYaml: `---
+template:
+  id: .hidden-template
+  author: test-user
+  version: 0.1.0
+`,
+			errorMsg: `The following attributes are missing in .+:\s+\* id must not start with '\.'`,
+		},
+		{
+			name:           "When config author and id both start with '.'",
+			mockConfigFile: true,
+			configFilePath: "my/dotfile/both/pct-config.yml",
+
+			configFileYaml: `---
+template:
+  id: .hidden-template
+  author: .hidden
+  version: 0.1.0
+`,
+			errorMsg: `The following attributes are missing in .+:\s+\* id must not start with '\.'\s+\* author must not start with '\.'`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -55,7 +55,7 @@ func (p *Installer) Install(templatePkg, targetDir string, force bool) (string, 
 	}
 
 	// create a temporary Directory to extract the tar.gz to
-	tempDir, err := p.AFS.TempDir("", "")
+	tempDir, err := p.AFS.TempDir(targetDir, ".pct")
 	defer func() {
 		err := p.AFS.RemoveAll(tempDir)
 		if err != nil {

--- a/pkg/mock/engine.go
+++ b/pkg/mock/engine.go
@@ -1,0 +1,20 @@
+package mock
+
+type Engine struct {
+	NameFn   func() string
+	RenderFn func(content string, vars map[string]interface{}) (string, error)
+}
+
+func (e *Engine) Name() string {
+	if e.NameFn == nil {
+		return "mock"
+	}
+	return e.NameFn()
+}
+
+func (e *Engine) Render(content string, vars map[string]interface{}) (string, error) {
+	if e.RenderFn == nil {
+		return content, nil
+	}
+	return e.RenderFn(content, vars)
+}

--- a/pkg/template/engine.go
+++ b/pkg/template/engine.go
@@ -1,0 +1,17 @@
+package template
+
+const DefaultEngineName = "go"
+
+type Engine interface {
+	Name() string
+	Render(content string, vars map[string]interface{}) (string, error)
+}
+
+var engines = map[string]Engine{
+	DefaultEngineName: &goEngine{},
+}
+
+func Get(name string) (Engine, bool) {
+	e, ok := engines[name]
+	return e, ok
+}

--- a/pkg/template/go_engine.go
+++ b/pkg/template/go_engine.go
@@ -1,0 +1,27 @@
+package template
+
+import (
+	"bytes"
+	gotemplate "text/template"
+
+	"github.com/jay7x/pct/pkg/utils"
+)
+
+type goEngine struct{}
+
+func (e *goEngine) Name() string { return DefaultEngineName }
+
+func (e *goEngine) Render(content string, vars map[string]interface{}) (string, error) {
+	tmpl, err := gotemplate.New("").Funcs(gotemplate.FuncMap{
+		"toClassName": utils.ToClassName,
+		"ns2path":     utils.Ns2Path,
+	}).Parse(content)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, vars); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/pkg/template/go_engine.go
+++ b/pkg/template/go_engine.go
@@ -7,15 +7,17 @@ import (
 	"github.com/jay7x/pct/pkg/utils"
 )
 
+var goFuncs = gotemplate.FuncMap{
+	"toClassName": utils.ToClassName,
+	"ns2path":     utils.Ns2Path,
+}
+
 type goEngine struct{}
 
 func (e *goEngine) Name() string { return DefaultEngineName }
 
 func (e *goEngine) Render(content string, vars map[string]interface{}) (string, error) {
-	tmpl, err := gotemplate.New("").Funcs(gotemplate.FuncMap{
-		"toClassName": utils.ToClassName,
-		"ns2path":     utils.Ns2Path,
-	}).Parse(content)
+	tmpl, err := gotemplate.New("").Funcs(goFuncs).Parse(content)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/template/go_engine_test.go
+++ b/pkg/template/go_engine_test.go
@@ -1,0 +1,96 @@
+package template_test
+
+import (
+	"testing"
+
+	"github.com/jay7x/pct/pkg/template"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoEngineName(t *testing.T) {
+	eng, ok := template.Get("go")
+	require.True(t, ok)
+	assert.Equal(t, "go", eng.Name())
+}
+
+func TestGoEngineRender(t *testing.T) {
+	eng, ok := template.Get("go")
+	require.True(t, ok)
+
+	tests := []struct {
+		name    string
+		content string
+		vars    map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "simple variable substitution",
+			content: "Hello {{.name}}!",
+			vars:    map[string]interface{}{"name": "world"},
+			want:    "Hello world!",
+		},
+		{
+			name:    "toClassName filter",
+			content: "class {{.name | toClassName}} { }",
+			vars:    map[string]interface{}{"name": "my_class"},
+			want:    "class My_class { }",
+		},
+		{
+			name:    "ns2path filter",
+			content: "{{.name | ns2path}}",
+			vars:    map[string]interface{}{"name": "profile::base"},
+			want:    "profile/base",
+		},
+		{
+			name:    "range loop",
+			content: "{{range $i, $v := .items}}{{if $i}},{{end}}{{$v}}{{end}}",
+			vars:    map[string]interface{}{"items": []string{"a", "b", "c"}},
+			want:    "a,b,c",
+		},
+		{
+			name:    "nil vars",
+			content: "static text",
+			vars:    nil,
+			want:    "static text",
+		},
+		{
+			name:    "empty content",
+			content: "",
+			vars:    map[string]interface{}{},
+			want:    "",
+		},
+		{
+			name:    "dot access on nested map",
+			content: "{{.puppet_module.version}}",
+			vars:    map[string]interface{}{"puppet_module": map[string]interface{}{"version": "0.1.0"}},
+			want:    "0.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := eng.Render(tt.content, tt.vars)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGoEngineRenderError(t *testing.T) {
+	eng, ok := template.Get("go")
+	require.True(t, ok)
+
+	_, err := eng.Render("{{.foo", nil)
+	assert.Error(t, err)
+}
+
+func TestGetUnknown(t *testing.T) {
+	_, ok := template.Get("nonexistent")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
This PR abstracts template rendering behind an Engine interface in pkg/template/ with the built-in "go" adapter wrapping text/template. Both content files (renderFile) and rename target expressions (renderTarget) now dispatch through template.Get(engineName).Render(...), honoring the Engine field in pct-config.yml.